### PR TITLE
ビルドエラーを修正

### DIFF
--- a/src/templates/blog-index.js
+++ b/src/templates/blog-index.js
@@ -33,7 +33,7 @@ const BlogIndex = ({ data, pageContext, location }) => {
             <section>
               <p
                 dangerouslySetInnerHTML={{
-                  __html: node.frontmatter.description || node.excerpt,
+                  __html: node.excerpt,
                 }}
               />
             </section>
@@ -82,7 +82,6 @@ export const pageQuery = graphql`
           frontmatter {
             date(formatString: "MMMM DD, YYYY")
             title
-            description
           }
         }
       }

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -15,7 +15,7 @@ const BlogPostTemplate = ({ data, pageContext, location }) => {
     <Layout location={location} title={siteTitle}>
       <SEO
         title={post.frontmatter.title}
-        description={post.frontmatter.description || post.excerpt}
+        description={post.excerpt}
       />
       <article>
         <header>
@@ -94,7 +94,6 @@ export const pageQuery = graphql`
       frontmatter {
         title
         date(formatString: "MMMM DD, YYYY")
-        description
       }
     }
   }


### PR DESCRIPTION
Markdownファイル内の冒頭にdescriptionがなかったのでエラーになっていた
デフォルト記事を削除したことで本エラーが発生していた
既存記事にはdescriptionは無いので一旦削除する